### PR TITLE
fix dotfiles coc install process

### DIFF
--- a/_nvimrc
+++ b/_nvimrc
@@ -18,7 +18,7 @@ Plug 'tpope/vim-vinegar'
 Plug 'jorgengz/minivimc'
 Plug 'bronson/vim-trailing-whitespace'
 Plug 'scrooloose/nerdtree'
-Plug 'neoclide/coc.nvim', {'do': 'yarn install --frozen-lockfile'}
+Plug 'neoclide/coc.nvim', { 'branch': 'release' }
 Plug 'StanAngeloff/php.vim'
 "Plug 'pangloss/vim-javascript'
 Plug 'HerringtonDarkholme/yats.vim'

--- a/install_neo_vim
+++ b/install_neo_vim
@@ -3,7 +3,7 @@
 mkdir -p ~/.config/nvim
 ln -s ~/.dotfiles/_nvimrc ~/.config/nvim/init.vim
 
-sudo add-apt-repository -y ppa:neovim-ppa/stable
+sudo add-apt-repository -y ppa:neovim-ppa/unstable
 sudo apt-get update
 sudo apt-get install -y curl neovim python-dev python-pip python3-dev python3-pip
 sudo update-alternatives --install /usr/bin/vi vi /usr/bin/nvim 60


### PR DESCRIPTION
### Summary

Installing `Coc` for neovim required the latest version of neovim. I have also ran into issues (now and in the past) with installing the `Coc` plugin with the existing plugin config (yarn requirement).

- Updated `install_neo_vim` script to install the latest version of neovim
- Updated `Coc` plugin arguments to avoid yarn usage

### Checked

Both neovim and `Coc` install without issue

